### PR TITLE
Fix jumping of Menu List when expanding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ android:
  
 script:
   - ./gradlew build 
-  - ./gradlew sonarqube
+  - test "${TRAVIS_PULL_REQUEST}" = "false" && ./gradlew sonarqube
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ android:
  
 script:
   - ./gradlew build 
-  - test "${TRAVIS_PULL_REQUEST}" = "true" || ./gradlew sonarqube
+  - test $TRAVIS_PULL_REQUEST != "false" || ./gradlew sonarqube
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ android:
  
 script:
   - ./gradlew build 
-  - test "${TRAVIS_PULL_REQUEST}" = "false" && ./gradlew sonarqube
+  - test "${TRAVIS_PULL_REQUEST}" = "true" || ./gradlew sonarqube
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/app/src/main/res/layout/fragment_mensa_detail.xml
+++ b/app/src/main/res/layout/fragment_mensa_detail.xml
@@ -15,7 +15,7 @@
             android:name="ch.famoser.mensa.ItemListFragment"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layoutManager="LinearLayoutManager"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             tools:listitem="@layout/row_menu_details"
             tools:itemCount="3"/>
 

--- a/app/src/main/res/layout/frame_location_list.xml
+++ b/app/src/main/res/layout/frame_location_list.xml
@@ -28,6 +28,7 @@
                     tools:context=".activities.MainActivity"
                     tools:listitem="@layout/row_location"
                     tools:itemCount="1"
+                    android:descendantFocusability="blocksDescendants"
                     tools:layout_height="200sp"/>
 
             <LinearLayout

--- a/app/src/main/res/layout/row_location.xml
+++ b/app/src/main/res/layout/row_location.xml
@@ -32,7 +32,7 @@
             android:name="ch.famoser.mensa.ItemListFragment"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layoutManager="LinearLayoutManager"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             tools:listitem="@layout/row_mensa"
             tools:itemCount="3"/>
 </LinearLayout>

--- a/app/src/main/res/layout/row_mensa.xml
+++ b/app/src/main/res/layout/row_mensa.xml
@@ -64,7 +64,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:visibility="gone"
-                    app:layoutManager="LinearLayoutManager"
+                    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                     tools:listitem="@layout/row_menu"
                     tools:itemCount="3"
                     tools:visibility="visible"/>

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ buildscript {
 }
 
 plugins {
-  id "org.sonarqube" version "2.7"
+  id "org.sonarqube" version "2.7.1"
 }
 
 allprojects {


### PR DESCRIPTION
Problem:
On Android 7.1.1 with the Xperia Z5, the menu jumped vertically after expanding and after hiding a specific Mensa's Menu List.

Fix:
Avoid issues of nested Focus and auto-scrollying of the RecyclerView by adding `descendantFocusability="blocksDescendants"` to SaveScrollRecyclerView layout.

See [here](https://stackoverflow.com/questions/36314836/recycler-view-inside-nestedscrollview-causes-scroll-to-start-in-the-middle), [here](https://stackoverflow.com/questions/37782485/android-prevent-nested-recyclerview-from-automatically-repositioning), [here](https://stackoverflow.com/questions/37850550/how-to-remove-focus-from-recyclerview-inside-scrollview) and [the docs](https://developer.android.com/reference/android/R.attr.html#descendantFocusability).

Other Changes in this PR:
```
            -  app:layoutManager="LinearLayoutManager"
            +  app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
```
Make LinearLayoutManager reference explicit because my IDE marked it as it could not find it. (Even though it _did_ build and run.)