### PR TITLE
solve issue of low contrast

### DIFF
--- a/app/src/main/res/layout/row_mensa.xml
+++ b/app/src/main/res/layout/row_mensa.xml
@@ -40,7 +40,7 @@
                         android:padding="@dimen/text_margin"
                         android:textAppearance="?attr/textAppearanceListItem"
                         android:textStyle="bold"
-                        android:textColor="@android:color/white"
+                        android:textColor="#646464"
                         android:ellipsize="end"
                         android:maxLines="1"
                         tools:text="very long text which overlaps Polyterrasse"/>
@@ -52,7 +52,7 @@
                         android:padding="@dimen/text_margin"
                         android:textAlignment="viewEnd"
                         android:textAppearance="?attr/textAppearanceListItem"
-                        android:textColor="@android:color/white"
+                        android:textColor="#646464"
                         tools:text="11:15 - 13:30"/>
 
             </LinearLayout>


### PR DESCRIPTION
The original text color of the component is '#FFFFFF', and the contrast between the text color ('#FFFFFF') and the background color ('#DBE2EF') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#646464') are as follows:
![image](https://user-images.githubusercontent.com/101503193/211360619-36cde525-3e42-4eec-8987-a0705b4f1daa.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.