### PR TITLE
Update Base Link for UZH Mensa Locations

### DIFF
--- a/app/src/main/java/ch/famoser/mensa/services/providers/UZHMensaProvider.kt
+++ b/app/src/main/java/ch/famoser/mensa/services/providers/UZHMensaProvider.kt
@@ -159,7 +159,7 @@ class UZHMensaProvider(
                     UUID.fromString(it.id),
                     it.title,
                     it.mealTime,
-                    URI("https://www.mensa.uzh.ch/de/standorte/${it.infoUrlSlug}.html")
+                    URI("https://www.mensa.uzh.ch/de/menueplaene/${it.infoUrlSlug}.html")
                 )
                 mensaMap[mensa] = it
                 mensa


### PR DESCRIPTION
Apparently UZH has changed the base link for the locations so I changed it accordingly.